### PR TITLE
Add theme colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "less-is-more",
-  "displayName": "Less is More",
+  "displayName": "Less Is More",
   "theme": "less-is-more",
   "version": "1.0.4",
   "description": "A less is more approach to email in Nylas N1",

--- a/styles/less-is-more.less
+++ b/styles/less-is-more.less
@@ -352,6 +352,10 @@ body.is-blurred .list-container .list-item.focused,
   border-right: none;
 }
 
+.find-in-thread {
+  border-bottom: none;
+}
+
 .list-tabular .list-tabular-item.keyboard-cursor .list-column:first-child {
   border-left: 0px solid @less-background;
   padding-left: 12px;

--- a/styles/theme-colors.less
+++ b/styles/theme-colors.less
@@ -1,0 +1,5 @@
+@background-secondary: white;
+@text-color: black;
+@component-active-color: #a6b7be;
+@toolbar-background-color: white;
+@panel-background-color: white;


### PR DESCRIPTION
Hey, @P0WW0W! I'm part of the Nylas team, and we're about to land a new visual theme picker that'll allow people to preview and view color palettes for themes. We pull a few major colors from the theme's UI variables to create the palette, but we've also added a way to override them manually with a `theme-colors.less` file for themes (like yours) that don't use the UI variables.

I also added a minor fix for a change that's landed on master (`.find-in-thread`) and should be in the app soon.
